### PR TITLE
[CAKER-2] Enable macOS target compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package =
     platforms: [
       .iOS(.v15),
       .watchOS(.v8),
+      .macOS(.v12),
     ],
     products: [
       .library(

--- a/Sources/SwiftUIGrid/FontFace+AppKit.swift
+++ b/Sources/SwiftUIGrid/FontFace+AppKit.swift
@@ -1,0 +1,60 @@
+#if os(macOS)
+
+import AppKit
+import SwiftUI
+
+extension FontFace {
+  /**
+   Converts the font to a NSAttributesString.Key map, with a specific size.
+   */
+  public func toAttributes(size: CGFloat) -> [NSAttributedString.Key : NSFont] {
+    if let name = name {
+      return [NSAttributedString.Key.font : NSFont(name: name, size: size)!]
+    } else {
+      return [
+        NSAttributedString.Key.font : NSFont.systemFont(ofSize: size, weight: weight.nsFontWeight)
+      ]
+    }
+  }
+  
+  /**
+   Converts the font to a NSAttributesString.Key map, with a specific size taken from a raw value of an enum.
+   */
+  public func toAttributes<Size : RawRepresentable>(
+    size: Size
+  ) -> [NSAttributedString.Key : NSFont] where Size.RawValue == CGFloat {
+    toAttributes(size: size.rawValue)
+  }
+}
+
+private extension Font.Weight {
+  /**
+   Convert `Font.Weight` to `NSFont.Weight`
+   */
+  var nsFontWeight: NSFont.Weight {
+    switch self {
+    case .ultraLight:
+      return .ultraLight
+    case .thin:
+      return .thin
+    case .light:
+      return .light
+    case .regular:
+      return .regular
+    case .medium:
+      return .medium
+    case .semibold:
+      return .semibold
+    case .bold:
+      return .bold
+    case .heavy:
+      return .heavy
+    case .black:
+      return .black
+    default:
+      return .regular
+    }
+  }
+}
+
+#endif

--- a/Sources/SwiftUIGrid/FontFace+UIKit.swift
+++ b/Sources/SwiftUIGrid/FontFace+UIKit.swift
@@ -1,0 +1,60 @@
+#if !os(macOS)
+
+import SwiftUI
+import UIKit
+
+
+extension FontFace {
+  /**
+   Converts the font to a NSAttributesString.Key map, with a specific size.
+   */
+  public func toAttributes(size: CGFloat) -> [NSAttributedString.Key : UIFont] {
+    if let name = name {
+      return [NSAttributedString.Key.font : UIFont(name: name, size: size)!]
+    } else {
+      return [
+        NSAttributedString.Key.font : UIFont.systemFont(ofSize: size, weight: weight.uiFontWeight)
+      ]
+    }
+  }
+  
+  /**
+   Converts the font to a NSAttributesString.Key map, with a specific size taken from a raw value of an enum.
+   */
+  public func toAttributes<Size : RawRepresentable>(
+    size: Size
+  ) -> [NSAttributedString.Key : UIFont] where Size.RawValue == CGFloat {
+    toAttributes(size: size.rawValue)
+  }
+}
+
+private extension Font.Weight {
+  /**
+   Convert `Font.Weight` to `UIFont.Weight`
+   */
+  var uiFontWeight: UIFont.Weight {
+    switch self {
+    case .ultraLight:
+      return .ultraLight
+    case .thin:
+      return .thin
+    case .light:
+      return .light
+    case .regular:
+      return .regular
+    case .medium:
+      return .medium
+    case .semibold:
+      return .semibold
+    case .bold:
+      return .bold
+    case .heavy:
+      return .heavy
+    case .black:
+      return .black
+    default:
+      return .regular
+    }
+  }
+}
+#endif

--- a/Sources/SwiftUIGrid/FontFace.swift
+++ b/Sources/SwiftUIGrid/FontFace.swift
@@ -41,28 +41,6 @@ public struct FontFace : Hashable {
   }
   
   /**
-   Converts the font to a NSAttributesString.Key map, with a specific size.
-   */
-  public func toAttributes(size: CGFloat) -> [NSAttributedString.Key : UIFont] {
-    if let name = name {
-      return [NSAttributedString.Key.font : UIFont(name: name, size: size)!]
-    } else {
-      return [
-        NSAttributedString.Key.font : UIFont.systemFont(ofSize: size, weight: weight.uiFontWeight)
-      ]
-    }
-  }
-  
-  /**
-   Converts the font to a NSAttributesString.Key map, with a specific size taken from a raw value of an enum.
-   */
-  public func toAttributes<Size : RawRepresentable>(
-    size: Size
-  ) -> [NSAttributedString.Key : UIFont] where Size.RawValue == CGFloat {
-    toAttributes(size: size.rawValue)
-  }
-  
-  /**
    Converts to a system or custom `Font` with a specific provided size.
    */
   public func toFont(size: CGFloat) -> Font {
@@ -114,36 +92,5 @@ extension View {
     size: Size
   ) -> some View where Size.RawValue == CGFloat {
     font(face.toFont(size: size.rawValue).smallCaps())
-  }
-}
-
-private extension Font.Weight {
-
-  /**
-   Convert `Font.Weight` to `UIFont.Weight`
-   */
-  var uiFontWeight: UIFont.Weight {
-    switch self {
-    case .ultraLight:
-      return .ultraLight
-    case .thin:
-      return .thin
-    case .light:
-      return .light
-    case .regular:
-      return .regular
-    case .medium:
-      return .medium
-    case .semibold:
-      return .semibold
-    case .bold:
-      return .bold
-    case .heavy:
-      return .heavy
-    case .black:
-      return .black
-    default:
-      return .regular
-    }
   }
 }


### PR DESCRIPTION
- splitting toAttributes implementation in FontFace into AppKit/UIKit variants
- adjusted package platforms

Work on xiiagency/Caker#2